### PR TITLE
fix: update Netlify configuration for Remix SSR

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -9,9 +9,8 @@
 
 [[redirects]]
   from = "/*"
-  to = "/index.html"
+  to = "/.netlify/functions/server"
   status = 200
-  force = true
 
 [functions]
   node_bundler = "esbuild"

--- a/netlify/functions/server.js
+++ b/netlify/functions/server.js
@@ -1,0 +1,7 @@
+import { createRequestHandler } from "@remix-run/netlify";
+import * as build from "../../build/index.js";
+
+export const handler = createRequestHandler({
+  build,
+  mode: process.env.NODE_ENV,
+});

--- a/package.json
+++ b/package.json
@@ -4,10 +4,10 @@
   "sideEffects": false,
   "type": "module",
   "scripts": {
-    "build": "remix build && mkdir -p build/client && cp -r public/* build/client/",
+    "build": "remix build && mkdir -p build/client && cp -r public/* build/client/ && cp -r build/client/.netlify .",
     "dev": "remix dev",
     "lint": "eslint --ignore-path .gitignore --cache --cache-location ./node_modules/.cache/eslint .",
-    "start": "remix-serve ./build/index.js",
+    "start": "netlify dev",
     "typecheck": "tsc",
     "generate-icons": "node scripts/generate-icons.js"
   },


### PR DESCRIPTION
Configuración actualizada para soportar Server-Side Rendering (SSR) en Netlify:

- Agregado servidor de funciones Netlify para manejar SSR
- Actualizada configuración de redirecciones en netlify.toml
- Modificado script de build para copiar archivos necesarios
- Configurado el manejo correcto de rutas para Remix

Estos cambios permitirán que la aplicación funcione correctamente en Netlify con SSR.